### PR TITLE
Improve clustering with FAISS

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -139,3 +139,4 @@ wrapt==1.16.0
 yapf==0.40.2
 yarl==1.9.4
 zipp==3.19.1
+faiss-gpu==1.7.2


### PR DESCRIPTION
## Summary
- refine k-means codebook generation using FAISS
- limit number of images loaded and feature points per class
- add optional FAISS GPU dependency

## Testing
- `python -m py_compile codebook_generation/minibatch_kmeans_per_class.py`
- `python -m py_compile $(find . -name '*.py' -not -path '*__pycache__*')`


------
https://chatgpt.com/codex/tasks/task_e_683fe46e65f88324a19a8b1cd8444c86